### PR TITLE
Edit nav bar layout

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,7 +23,7 @@
         {{ end }}
         </div>
         <div class="col hide-on-small-only m3 l3">
-            <div id="sideMenu">
+            <div id="sideMenu" class="override-justify">
                 <ul class="section table-of-contents">
                 {{ range $index, $element := .Params.sideMenuIds }}
                     <li><a href="#{{ $element }}">{{ index $.Params.sideMenuNames $index }}</a></li>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,5 +1,7 @@
-<header class="site-header">
-	<div class="branding">
+<nav class="site-header">
+
+<div class="nav-wrapper">
+  	<div class="left branding valign-wrapper">
 		<a href="{{ .Site.BaseURL }}">
 		{{ with .Site.Params.gravatar -}}
 			<img class="avatar" src="https://www.gravatar.com/avatar/{{ . | md5 }}?s=100&d=identicon" alt=""/>
@@ -11,11 +13,33 @@
 			<a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
 		</h1>
 	</div>
-	<nav class="site-nav">
-		<ul>
-	      	{{ range .Site.Menus.nav -}}
+
+		<div class="right">
+			<ul id="nav-mobile" class="site-nav hide-on-med-and-down">
+        {{ range .Site.Menus.nav -}}
 	        	<li><a href="{{ .URL }}"> {{ .Name }} </a></li>
 	      	{{- end }}
-	    </ul>
-	</nav>
-</header>
+      	</ul>
+
+
+		</div>
+
+		<div class="right valign-wrapper">
+      		<a href="#" data-activates="mobile-demo" class="button-collapse"><i class="material-icons">menu</i></a>
+      	<ul class="side-nav right" id="mobile-demo">
+	        {{ range .Site.Menus.nav -}}
+	        	<li><a href="{{ .URL }}"> {{ .Name }} </a></li>
+	      	{{- end }}
+	      </ul>
+      	</div>
+
+</div>
+</nav>
+
+<script>
+	$( document ).ready(function(){
+		$(".button-collapse").sideNav({
+			edge: 'right'
+		});
+	});
+</script>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,44 +1,41 @@
 <nav class="site-header">
+	<div class="nav-wrapper">
+	  	<div class="left branding valign-wrapper">
+			<a href="{{ .Site.BaseURL }}">
+			{{ with .Site.Params.gravatar -}}
+				<img class="avatar" src="https://www.gravatar.com/avatar/{{ . | md5 }}?s=100&d=identicon" alt=""/>
+			{{- else -}}
+				<img class="avatar" src="{{ .Site.BaseURL }}{{ .Site.Params.avatar }}" alt=""/>
+			{{- end }}
+			</a>
+			<h1 class="site-title">
+				<a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+			</h1>
+		</div>
 
-<div class="nav-wrapper">
-  	<div class="left branding valign-wrapper">
-		<a href="{{ .Site.BaseURL }}">
-		{{ with .Site.Params.gravatar -}}
-			<img class="avatar" src="https://www.gravatar.com/avatar/{{ . | md5 }}?s=100&d=identicon" alt=""/>
-		{{- else -}}
-			<img class="avatar" src="{{ .Site.BaseURL }}{{ .Site.Params.avatar }}" alt=""/>
-		{{- end }}
-		</a>
-		<h1 class="site-title">
-			<a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
-		</h1>
-	</div>
-
-		<div class="right">
-			<ul id="nav-mobile" class="site-nav hide-on-med-and-down">
-        {{ range .Site.Menus.nav -}}
+		<div class="right hide-on-med-and-down">
+			<ul id="nav-menu" class="site-nav">
+        	{{ range .Site.Menus.nav -}}
 	        	<li><a href="{{ .URL }}"> {{ .Name }} </a></li>
 	      	{{- end }}
-      	</ul>
-
-
+      		</ul>
 		</div>
 
 		<div class="right valign-wrapper">
-      		<a href="#" data-activates="mobile-demo" class="button-collapse"><i class="material-icons">menu</i></a>
-      	<ul class="side-nav right" id="mobile-demo">
+      		<a href="#" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">menu</i></a>
+	      	<ul id="nav-mobile" class="side-nav">
 	        {{ range .Site.Menus.nav -}}
 	        	<li><a href="{{ .URL }}"> {{ .Name }} </a></li>
 	      	{{- end }}
-	      </ul>
+		     </ul>
       	</div>
-
-</div>
+	</div>
 </nav>
 
 <script>
 	$( document ).ready(function(){
 		$(".button-collapse").sideNav({
+			menuWidth: 250,
 			edge: 'right'
 		});
 	});

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -60,3 +60,15 @@ nav {
   background-color: transparent;
   box-shadow: none;
 }
+
+.avatar {
+  width: 10%;
+}
+
+.nav-wrapper {
+  width: 100%;
+}
+
+.valign-wrapper {
+  height: 100%;
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -14,6 +14,10 @@ div {
   text-justify: inter-word;
 }
 
+.override-justify {
+  text-align: left;
+}
+
 .site-footer {
   background-color: white;
 }


### PR DESCRIPTION
### Redo nav bar layout, make it responsive
- height also wraps around content now
- didn't change background colour because not sure if there's any colour scheme at the moment
- note: not sure if responsive works ok for all phone sizes, tested on google chrome mobile views
Looks ok:
![image](https://user-images.githubusercontent.com/16895138/27768026-56493a16-5f3b-11e7-922c-f23f06e1cb40.png)
Galaxy S5 (360 x 640, quite small), menu misaligned:
![image](https://user-images.githubusercontent.com/16895138/27768029-61666388-5f3b-11e7-8b07-ed8a8ca9cec8.png)


### Minor edit to side menu in about page
- this is due to previous edit to justify all text, in cases when justify is not needed, can use .override-justify to align it back to left
Before:
![image](https://user-images.githubusercontent.com/16895138/27768001-a9099f26-5f3a-11e7-94ef-e1f0ebbb40ac.png)
After:
![image](https://user-images.githubusercontent.com/16895138/27768002-b55d92d2-5f3a-11e7-809c-8fa13347f63b.png)

Thank you for reading~